### PR TITLE
Fix blue bold text in lists

### DIFF
--- a/docs/styles/homepage.css
+++ b/docs/styles/homepage.css
@@ -38,8 +38,9 @@
 }
 
 /* Philosophy Section */
+/* Remove custom color for bold text to avoid link-like blue styling */
 .md-content h2 + p + ul li strong {
-    color: var(--md-primary-fg-color);
+    color: inherit;
 }
 
 /* Icon Enhancements */


### PR DESCRIPTION
## Summary
- stop styling strong tags in philosophy section like links

## Testing
- `mkdocs build -q`


------
https://chatgpt.com/codex/tasks/task_e_68518031431c83268f004105a44963a6