### PR TITLE
Add research summary and tags

### DIFF
--- a/docs/2025/02/09/project-jsync__jira-exporter-and-synchronization-system.md
+++ b/docs/2025/02/09/project-jsync__jira-exporter-and-synchronization-system.md
@@ -3,6 +3,10 @@ title: "Project JSync: JIRA Exporter and Synchronization System"
 authors: ["Dinis Cruz", "ChatGPT Deep Research"]
 date: 2025/02/09
 pdf_file: project-jsync__jira-exporter-and-synchronization-system.pdf
+description: |
+  Serverless pipeline that captures JIRA issue changes in real time and stores
+  them in S3 and GitHub, exposing a FastAPI interface for querying the data.
+tags: [serverless, JIRA, data-synchronization, AWS, devops]
 linkedin: diniscruz_project-plan-jira-export-to-s3-and-git-activity-7294766710589456385-9XBZ
 back_link: /research/projects
 ---

--- a/docs/2025/02/13/project-lumos__serverless-jira-to-graphdb-xyz-connector.md
+++ b/docs/2025/02/13/project-lumos__serverless-jira-to-graphdb-xyz-connector.md
@@ -3,6 +3,10 @@ title: "Project Lumos: Serverless JIRA-to-GraphDB XYZ Connector"
 authors: ["Dinis Cruz", "ChatGPT Deep Research", "Claude 3.5 Sonnet"]
 date: 2025/02/13
 pdf_file: project-lumos__serverless-jira-to-graphdb-xyz-connector.pdf
+description: |
+  Working Backwards plan for an open-source connector that streams JIRA data
+  into GraphDB XYZ using a fully serverless architecture.
+tags: [JIRA, GraphDB, serverless, data-streaming, open-source]
 linkedin: diniscruz_project-lumos-activity-7295968679869972480-NYGC
 back_link: /research/projects
 ---

--- a/docs/2025/02/15/project-supplyshield__genai-driven-supply-chain-risk-management-and-compliance.md
+++ b/docs/2025/02/15/project-supplyshield__genai-driven-supply-chain-risk-management-and-compliance.md
@@ -3,6 +3,10 @@ title: "Project SupplyShield: GenAI-Driven Supply Chain Risk Management and Comp
 authors: ["Dinis Cruz", "ChatGPT Deep Research"]
 date: 2025/02/15
 pdf_file: project-supplyshield__genai-driven-supply-chain-risk-management-and-compliance.pdf
+description: |
+  Introduces an AI-powered third-party risk platform that uses generative
+  models and knowledge graphs to deliver continuous supply chain compliance.
+tags: [genai, supply-chain, risk-management, compliance, knowledge-graph]
 linkedin: diniscruz_genai-driven-supply-chain-risk-management-activity-7296674764733992961-4otf
 back_link: /research/projects
 ---

--- a/docs/2025/03/01/project-startllm__technical-proposal-for-5x-genai-projects.md
+++ b/docs/2025/03/01/project-startllm__technical-proposal-for-5x-genai-projects.md
@@ -3,6 +3,10 @@ title: "Project StartLLM: Technical Proposal for 5x GenAI Projects"
 authors: ["Dinis Cruz", "ChatGPT Deep Research", "Claude 3.7"]
 date: 2025/03/01
 pdf_file: project-startllm__technical-proposal-for-5x-genai-projects.pdf
+description: |
+  Strategic proposal outlining five focused generative AI projects designed to
+  deliver quick wins and accelerate organizational adoption.
+tags: [genai, strategy, adoption, quick-wins, proposals]
 linkedin: diniscruz_project-startllm-activity-7301579711359442944-jtkn
 back_link: /research/projects
 ---

--- a/docs/2025/03/01/project-startllm__uc-01__pentesting-insight-acceleration.md
+++ b/docs/2025/03/01/project-startllm__uc-01__pentesting-insight-acceleration.md
@@ -3,6 +3,10 @@ title: "Project StartLLM: UC-01: Pentesting Insights Acceleration (PIA)"
 authors: ["Dinis Cruz", Claude 3.7"]
 date: 2025/03/01
 pdf_file: project-startllm__uc-01__pentesting-insight-acceleration.pdf
+description: |
+  Explores how generative AI can streamline pentesting workflows by
+  summarizing findings and highlighting priorities for faster remediation.
+tags: [pentesting, genai, workflow, summarization, security]
 linkedin: diniscruz_uc-01-pentesting-insights-acceleration-activity-7301699689773490177-1lnW/
 back_link: /research/projects
 ---

--- a/docs/2025/04/10/project-agenda__gen-ai-powered-transformation-of-meetings-and-documentation.md
+++ b/docs/2025/04/10/project-agenda__gen-ai-powered-transformation-of-meetings-and-documentation.md
@@ -3,6 +3,10 @@ title: "Project Agenda: GenAI-Powered Transformation of Meetings and Documentati
 authors: ["Dinis Cruz", "ChatGPT Deep Research", "Claude 3.7"]
 date: 2025/04/10
 pdf_file: project-agenda__gen-ai-powered-transformation-of-meetings-and-documentation.pdf
+description: |
+  Introduces a GenAI-driven workflow that prepares meetings, generates
+  personalized briefs and tracks action items to reduce wasted time.
+tags: [meetings, documentation, genai, action-items, productivity]
 back_link: /research/projects
 ---
 

--- a/docs/2025/04/10/project-cybersage__ai-powered-risk-contextualization_security-reporting.md
+++ b/docs/2025/04/10/project-cybersage__ai-powered-risk-contextualization_security-reporting.md
@@ -3,6 +3,11 @@ title: "Project Cybersage: AI-Powered Risk Contextualization & Security Reportin
 authors: ["Dinis Cruz", "ChatGPT Deep Research"]
 date: 2025/04/10
 pdf_file: project-cybersage__ai-powered-risk-contextualization_security-reporting.pdf
+description: |
+  Proposal for an AI platform that contextualizes vulnerability data and
+  generates clear, risk-based security reports for technical and executive
+  audiences.
+tags: [risk-contextualization, vulnerability-reporting, AI, security, automation]
 linkedin: diniscruz_ai-powered-risk-contextualization-security-activity-7295442983603064834-PVFZ
 back_link: /research/projects
 ---

--- a/docs/2025/05/03/project-insightflow__genai-powered-transformation-of-regulatory-and-news-feeds.md
+++ b/docs/2025/05/03/project-insightflow__genai-powered-transformation-of-regulatory-and-news-feeds.md
@@ -3,6 +3,10 @@ title: "Project InsightFlow: GenAI-Powered Transformation of Regulatory and News
 authors: ["Dinis Cruz", "ChatGPT Deep Research"]
 date: 2025/05/03
 pdf_file: project-insightflow__genai-powered-transformation-of-regulatory-and-news-feeds.pdf
+description: |
+  Describes a semantic knowledge graph pipeline that ingests regulations and
+  news, using generative AI to deliver personalized client newsletters.
+tags: [regulations, news, semantic-knowledge-graph, genai, personalization]
 linkedin: diniscruz_insightflow-genai-transformation-of-regulatory-activity-7324404009560137728-LC0r
 back_link: /research/projects
 ---

--- a/docs/2025/05/04/project-genbnb__enhancing-airbnb-host-workflows-with-gen-ai.md
+++ b/docs/2025/05/04/project-genbnb__enhancing-airbnb-host-workflows-with-gen-ai.md
@@ -3,6 +3,10 @@ title: "Project GenBnB: Enhancing Airbnb Host Workflows with GenAI"
 authors: ["Dinis Cruz", "ChatGPT Deep Research"]
 date: 2025/05/04
 pdf_file: project-genbnb__enhancing-airbnb-host-workflows-with-gen-ai.pdf
+description: |
+  Explores using generative AI to automate property listings and customer
+  interactions so Airbnb hosts can focus on high-value tasks.
+tags: [airbnb, generative-ai, automation, property-management, customer-interaction]
 back_link: /research/projects
 ---
 _by {{ authors | join(" and ") }}, {{ date }}_

--- a/docs/2025/05/18/project__web-content-capture-extension-with-pyodide-and-serverless-backend.md
+++ b/docs/2025/05/18/project__web-content-capture-extension-with-pyodide-and-serverless-backend.md
@@ -3,6 +3,11 @@ title: "Project: Web Content Capture Extension with Pyodide and Serverless Backe
 authors: ["ChatGPT Deep Research"]
 date: 2025/05/18
 pdf_file: project__web-content-capture-extension-with-pyodide-and-serverless-backend.pdf
+description: |
+  Prototype browser extension leveraging Pyodide and a serverless backend to
+  capture webpage content, including a debrief on why the initial approach
+  failed.
+tags: [web-extension, pyodide, serverless, content-capture, prototype]
 linkedin: diniscruz_project-brief-web-content-capture-extension-activity-7330166771137613824-NI5Y
 back_link: /research/projects
 youtube_id: OQiCjD0BN3s

--- a/docs/research/research-document.md
+++ b/docs/research/research-document.md
@@ -1,0 +1,34 @@
+# Research Document Catalog
+
+This page summarizes recent research proposals and technical briefs. Articles are grouped by month with the most recent entries listed first.
+
+## May 2025
+
+| Date | Title | Description | Tags |
+| --- | --- | --- | --- |
+| 2025-05-18 | [Project: Web Content Capture Extension with Pyodide and Serverless Backend](../2025/05/18/project__web-content-capture-extension-with-pyodide-and-serverless-backend.md) | Prototype browser extension leveraging Pyodide and a serverless backend to capture webpage content, including a debrief on why the initial approach failed. | web-extension, pyodide, serverless, content-capture, prototype |
+| 2025-05-04 | [Project GenBnB: Enhancing Airbnb Host Workflows with GenAI](../2025/05/04/project-genbnb__enhancing-airbnb-host-workflows-with-gen-ai.md) | Explores using generative AI to automate property listings and customer interactions so Airbnb hosts can focus on high-value tasks. | airbnb, generative-ai, automation, property-management, customer-interaction |
+| 2025-05-03 | [Project InsightFlow: GenAI-Powered Transformation of Regulatory and News Feeds](../2025/05/03/project-insightflow__genai-powered-transformation-of-regulatory-and-news-feeds.md) | Describes a semantic knowledge graph pipeline that ingests regulations and news, using generative AI to deliver personalized client newsletters. | regulations, news, semantic-knowledge-graph, genai, personalization |
+
+## April 2025
+
+| Date | Title | Description | Tags |
+| --- | --- | --- | --- |
+| 2025-04-10 | [Project Cybersage: AI-Powered Risk Contextualization & Security Reporting](../2025/04/10/project-cybersage__ai-powered-risk-contextualization_security-reporting.md) | Proposal for an AI platform that contextualizes vulnerability data and generates clear, risk-based security reports for technical and executive audiences. | risk-contextualization, vulnerability-reporting, AI, security, automation |
+| 2025-04-10 | [Project Agenda: GenAI-Powered Transformation of Meetings and Documentation](../2025/04/10/project-agenda__gen-ai-powered-transformation-of-meetings-and-documentation.md) | Introduces a GenAI-driven workflow that prepares meetings, generates personalized briefs and tracks action items to reduce wasted time. | meetings, documentation, genai, action-items, productivity |
+
+## March 2025
+
+| Date | Title | Description | Tags |
+| --- | --- | --- | --- |
+| 2025-03-01 | [Project StartLLM: Technical Proposal for 5x GenAI Projects](../2025/03/01/project-startllm__technical-proposal-for-5x-genai-projects.md) | Strategic proposal outlining five focused generative AI projects designed to deliver quick wins and accelerate organizational adoption. | genai, strategy, adoption, quick-wins, proposals |
+| 2025-03-01 | [Project StartLLM: UC-01: Pentesting Insights Acceleration (PIA)](../2025/03/01/project-startllm__uc-01__pentesting-insight-acceleration.md) | Explores how generative AI can streamline pentesting workflows by summarizing findings and highlighting priorities for faster remediation. | pentesting, genai, workflow, summarization, security |
+
+## February 2025
+
+| Date | Title | Description | Tags |
+| --- | --- | --- | --- |
+| 2025-02-15 | [Project SupplyShield: GenAI-Driven Supply Chain Risk Management and Compliance](../2025/02/15/project-supplyshield__genai-driven-supply-chain-risk-management-and-compliance.md) | Introduces an AI-powered third-party risk platform that uses generative models and knowledge graphs to deliver continuous supply chain compliance. | genai, supply-chain, risk-management, compliance, knowledge-graph |
+| 2025-02-13 | [Project Lumos: Serverless JIRA-to-GraphDB XYZ Connector](../2025/02/13/project-lumos__serverless-jira-to-graphdb-xyz-connector.md) | Working Backwards plan for an open-source connector that streams JIRA data into GraphDB XYZ using a fully serverless architecture. | JIRA, GraphDB, serverless, data-streaming, open-source |
+| 2025-02-09 | [Project JSync: JIRA Exporter and Synchronization System](../2025/02/09/project-jsync__jira-exporter-and-synchronization-system.md) | Serverless pipeline that captures JIRA issue changes in real time and stores them in S3 and GitHub, exposing a FastAPI interface for querying the data. | serverless, JIRA, data-synchronization, AWS, devops |
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -124,6 +124,7 @@ nav:
     - The Future of News: research/the-future-of-news.md
     - Europe & Learning: research/europe-and-learning.md
   - Projects: research/projects.md
+  - Research Document: research/research-document.md
   - Resources:
     - Presentations: resources/presentations.md
   - About: about.md


### PR DESCRIPTION
## Summary
- catalog 10 research documents in a monthly table
- register the new summary page in navigation
- tag each project document with 5 keywords

## Testing
- `pip install -e ".[docs]"`
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_68517b173ba0832696baf185b9f91d66