### PR TITLE
Add descriptions and tags to pages

### DIFF
--- a/docs/2025/01/29/my-journey-building_a_genai_startup__the-power-of-mvps-and-ci-pipelines__part-1.md
+++ b/docs/2025/01/29/my-journey-building_a_genai_startup__the-power-of-mvps-and-ci-pipelines__part-1.md
@@ -3,6 +3,8 @@ title: "My Journey Building a GenAI Startup: The Power of MVPs and CI Pipelines 
 authors: ["Dinis Cruz"]
 date: 2025/01/29
 file_name: my-journey-building_a_genai_startup__the-power-of-mvps-and-ci-pipelines__part-1.pdf
+description: "Presentation covering early lessons from building a GenAI startup."
+tags: [startup, genai, mvp, ci-pipelines]
 linkedin: diniscruz_my-journey-building-a-genai-startup-activity-7290683665934614529-Qejx
 back_link: /resources/presentations
 ---

--- a/docs/2025/03/03/linkedin-vault__professional-data-preservation-servic.md
+++ b/docs/2025/03/03/linkedin-vault__professional-data-preservation-servic.md
@@ -3,6 +3,8 @@ title: "LinkedIn Vault: Professional Data Preservation Service"
 authors: ["Dinis Cruz", "ChatGPT Deep Research"]
 date: 2025/03/03
 pdf_file: linkedin-vault__professional-data-preservation-service.pdf
+description: "Automates regular backups of LinkedIn career data to user storage."
+tags: [linkedin, data-preservation, automation, professional-data]
 linkedin: diniscruz_linkedinvault-professional-data-preservation-activity-7302308121249497088-uOCF
 back_link: /research/projects
 ---

--- a/docs/2025/03/24/journalists-challenges-with-digital-content-provenance-and-trust.md
+++ b/docs/2025/03/24/journalists-challenges-with-digital-content-provenance-and-trust.md
@@ -3,6 +3,8 @@ title: "Journalists' Challenges with Digital Content Provenance and Trust"
 authors: ["Dinis Cruz", "ChatGPT Deep Research"]
 date: 2025/03/24
 pdf_file: journalists-challenges-with-digital-content-provenance-and-trust.pdf
+description: "Explores how semantic graphs build trust in AI-generated news."
+tags: [journalism, provenance, trust, semantic-graphs]
 linkedin: diniscruz_journalists-challenges-with-digital-content-activity-7309971769845559296-j2j4
 back_link: /research/the-future-of-news
 ---

--- a/docs/2025/03/29/from-top-down-to-organic-evolving-graphs-ontologies-and-taxonomies.md
+++ b/docs/2025/03/29/from-top-down-to-organic-evolving-graphs-ontologies-and-taxonomies.md
@@ -3,6 +3,8 @@ title: "From Top-Down to Organic Evolving Graphs, Ontologies, and Taxonomies"
 authors: ["Dinis Cruz", "ChatGPT Deep Research"]
 date: 2025/03/29
 pdf_file: from-top-down-to-organic-evolving-graphs-ontologies-taxonomies.pdf
+description: "Discusses dynamic, community-driven approaches to building knowledge graphs."
+tags: [knowledge-graphs, ontologies, taxonomy, evolution]
 back_link: /research/graphs
 ---
 

--- a/docs/2025/03/31/scaling-europe-regulatory-superpower.md
+++ b/docs/2025/03/31/scaling-europe-regulatory-superpower.md
@@ -3,6 +3,8 @@ title: "Scaling Europe’s Regulatory Superpower: From Static Cybersecurity Stan
 authors: ["Dinis Cruz", "ChatGPT Deep Research"]
 date: 2025/03/31
 pdf_file: scaling-europe-regulatory-superpower.pdf
+description: "White paper on using semantic graphs to manage EU cybersecurity standards."
+tags: [europe, regulations, cybersecurity, knowledge-graphs]
 ---
 
 _by {{ authors | join(" and ") }}, {{ date }}_  

--- a/docs/2025/05/18/oauth-security-concerns-and-implications-for-the-model-context-protocol.md
+++ b/docs/2025/05/18/oauth-security-concerns-and-implications-for-the-model-context-protocol.md
@@ -3,6 +3,8 @@ title: "OAuth Security Concerns and Implications for the Model Context Protocol 
 authors: ["ChatGPT Deep Research"]
 date: 2025/05/18
 pdf_file: oauth-security-concerns-and-implications-for-the-model-context-protocol.pdf
+description: "Discusses OAuth risks in relation to the Model Context Protocol."
+tags: [oauth, security, mcp, protocol]
 linkedin: diniscruz_oauth-security-concerns-and-implications-activity-7329997030649442305-P0rG
 back_link: /research/cyber-security
 ---

--- a/docs/2025/05/18/security-debrief__openai_chatgpt_connector_gitHub_app.md
+++ b/docs/2025/05/18/security-debrief__openai_chatgpt_connector_gitHub_app.md
@@ -3,6 +3,8 @@ title: "Security Debrief: OpenAI’s ChatGPT Connector GitHub App"
 authors: ["ChatGPT Deep Research"]
 date: 2025/05/18
 pdf_file: security-debrief__openai_chatgpt_connector_gitHub_app.pdf
+description: "Analyzes security implications of the ChatGPT Connector GitHub app."
+tags: [security, github, chatgpt, connector]
 linkedin: diniscruz_security-debrief-openais-chatgpt-connector-activity-7329986369353650176-eUNV
 back_link: /research/cyber-security
 ---

--- a/docs/2025/05/22/technical-debrief__evolution-from-electron-based-to-python-native-web-content-capture-app.md
+++ b/docs/2025/05/22/technical-debrief__evolution-from-electron-based-to-python-native-web-content-capture-app.md
@@ -3,6 +3,8 @@ title: "Technical Debrief: Evolution from Electron‑Based to Python‑Native We
 authors: ["ChatGPT Deep Research"]
 date: 2025/05/22
 pdf_file: technical-debrief__evolution-from-electron-based-to-python-native-web-content-capture-app.pdf
+description: "Lessons learned migrating a web capture tool from Electron to Python."
+tags: [technical-debrief, python, electron, web-content]
 back_link: /research/projects
 linkedin: diniscruz_technical-debrief-evolution-from-electronbased-activity-7330989236768145408-KXUz
 youtube_id: s7G42SIdAX8

--- a/docs/2025/05/27/lets__load-extract-transform-save__a-deterministic-and-debuggable-data-pipeline_architecture.md
+++ b/docs/2025/05/27/lets__load-extract-transform-save__a-deterministic-and-debuggable-data-pipeline_architecture.md
@@ -3,6 +3,8 @@ title: "LETS (Load, Extract, Transform, Save): A Deterministic and Debuggable Da
 authors: ["Dinis Cruz", "ChatGPT Deep Research"]
 date: 2025/05/27
 pdf_file: lets__load-extract-transform-save__a-deterministic-and-debuggable-data-pipeline_architecture.pdf
+description: "Outline of a deterministic, debuggable data pipeline architecture."
+tags: [data-pipeline, architecture, deterministic, debugging]
 back_link: /research/development-and-genai
 linkedin: diniscruz_lets-load-extract-transform-save-activity-7333166696649621505-ZjqA
 ---

--- a/docs/2025/05/29/advancing-threat-modeling-with-semantic-knowledge-graphs.md
+++ b/docs/2025/05/29/advancing-threat-modeling-with-semantic-knowledge-graphs.md
@@ -3,6 +3,8 @@ title: "Advancing Threat Modeling with Semantic Knowledge Graphs"
 authors: ["Dinis Cruz", "ChatGPT Deep Research"]
 date: 2025/05/29
 pdf_file: advancing-threat-modeling-with-semantic-knowledge-graphs.pdf
+description: "Shows how semantic knowledge graphs enhance threat modeling practices."
+tags: [threat-modeling, knowledge-graphs, cybersecurity]
 back_link: /research/cyber-security
 linkedin: diniscruz_advancing-threat-modeling-with-semantic-knowledge-activity-7334009715133177858-5uN3
 ---

--- a/docs/2025/05/29/semantic-knowledge-graphs-for-llm-driven-source-code-analysis.md
+++ b/docs/2025/05/29/semantic-knowledge-graphs-for-llm-driven-source-code-analysis.md
@@ -3,6 +3,8 @@ title: "Semantic Knowledge Graphs for LLM-Driven Source Code Analysis"
 authors: ["Dinis Cruz", "ChatGPT Deep Research"]
 date: 2025/05/29
 pdf_file: semantic-knowledge-graphs-for-llm-driven-source-code-analysis.pdf
+description: "Using knowledge graphs and large language models for analyzing source code."
+tags: [knowledge-graphs, source-code, llm, analysis]
 back_link: /research/cyber-security
 #linkedin: to-do
 ---

--- a/docs/2025/05/29/threat-models-as-mandatory-disclosures__a-vision-for-security-transparency.md
+++ b/docs/2025/05/29/threat-models-as-mandatory-disclosures__a-vision-for-security-transparency.md
@@ -3,6 +3,8 @@ title: "Threat Models as Mandatory Disclosures: A Vision for Security Transparen
 authors: ["Dinis Cruz", "ChatGPT Deep Research"]
 date: 2025/05/29
 pdf_file: threat-models-as-mandatory-disclosures__a-vision-for-security-transparency.pdf
+description: "Argues that publishing threat models improves security transparency."
+tags: [threat-modeling, transparency, disclosure]
 back_link: /research/cyber-security
 linkedin: diniscruz_threat-models-as-mandatory-disclosures-activity-7333890904111374337-GnjN
 ---

--- a/docs/research/cyber-security.md
+++ b/docs/research/cyber-security.md
@@ -1,3 +1,8 @@
+---
+description: "Index of articles on threat modeling and modern AppSec."
+tags: [cybersecurity, threat-modeling, appsec]
+---
+
 
 # Cyber-security
 

--- a/docs/research/development-and-genai.md
+++ b/docs/research/development-and-genai.md
@@ -1,3 +1,8 @@
+---
+description: "Hub for resources on generative AI and modern development."
+tags: [development, genai, automation]
+---
+
 # Development and GenAI
 
 {{back_button('/index')}}

--- a/docs/research/europe-and-learning.md
+++ b/docs/research/europe-and-learning.md
@@ -1,3 +1,8 @@
+---
+description: "Overview page linking GenAI opportunities in Europe and learning resources."
+tags: [europe, genai, learning, research]
+---
+
 # Europe and Learning
 
 {{back_button('/index')}}

--- a/docs/research/graphs.md
+++ b/docs/research/graphs.md
@@ -1,3 +1,8 @@
+---
+description: "Guides on graph databases, ontologies, and semantic knowledge graphs."
+tags: [graphs, knowledge-graphs, ontologies]
+---
+
 # Graphs
 
 {{back_button('/index')}}

--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -1,3 +1,9 @@
+---
+description: "Portal to articles on AI, cybersecurity, and knowledge graphs."
+tags: [research, hub, ai, cybersecurity, graphs]
+---
+
+
 # Research Hub
 
 Welcome to the Dinis Cruz Research Hub, where I explore the intersection of AI, cybersecurity, and knowledge management through practical projects and innovative approaches.

--- a/docs/research/projects.md
+++ b/docs/research/projects.md
@@ -1,3 +1,8 @@
+---
+description: "Collection of research projects and business ideas exploring generative AI."
+tags: [projects, genai, innovation]
+---
+
 # Projects and Business Ideas
 
 {{back_button('/index')}}

--- a/docs/research/research-document.md
+++ b/docs/research/research-document.md
@@ -1,3 +1,8 @@
+---
+description: "Table summarizing research proposals and briefs."
+tags: [catalog, research, summaries]
+---
+
 # Research Document Catalog
 
 This page summarizes recent research proposals and technical briefs. Articles are grouped by month with the most recent entries listed first.

--- a/docs/research/the-future-of-news.md
+++ b/docs/research/the-future-of-news.md
@@ -1,3 +1,9 @@
+---
+description: "Articles on news monetization, fact provenance, and trust."
+tags: [news, trust, provenance, monetization]
+---
+
+
 # The Future of news
 
 {{back_button('/index')}}


### PR DESCRIPTION
## Summary
- add description and tags front matter to research index pages
- add description and tags to project documents

## Testing
- `mkdocs build --strict` *(fails: Aborted with 2 warnings in strict mode)*

------
https://chatgpt.com/codex/tasks/task_e_68687515949883269a8df93eb8f2582b